### PR TITLE
Check for support for the deprecated `platform.dist()` method

### DIFF
--- a/pyinfo/_pyinfo.py
+++ b/pyinfo/_pyinfo.py
@@ -70,7 +70,7 @@ def collect_system_info():
     if hasattr(sys, 'subversion'):
         data['Python Subversion'] = ', '.join(sys.subversion)
 
-    if platform.dist()[0] != '' and platform.dist()[1] != '':
+    if hasattr(platform, 'dist') and platform.dist()[0] != '' and platform.dist()[1] != '':
         osversion = '{} {} ({} {})'.format(platform.system(),
                                            platform.release(),
                                            platform.dist()[0].capitalize(),


### PR DESCRIPTION
In python/cpython#6871 `dist()` has been removed.

This is a check if the method exists or not.

Closes #1